### PR TITLE
Crystal test data

### DIFF
--- a/data/legend/metadata/hardware/detectors/germanium/crystals/B99000.json
+++ b/data/legend/metadata/hardware/detectors/germanium/crystals/B99000.json
@@ -1,0 +1,14 @@
+{
+  "name": "000",
+  "order": "99",
+  "enrichment": 0.88,
+  "impurity_measurements": {
+    "value_in_1e9e_cm3": [9, 10, 12, 13, 20],
+    "distance_from_seed_end_mm": [0, 27, 50, 80, 110]
+  },
+  "slices": {
+    "A": {
+      "detector_offset_in_mm": 40
+    }
+  }
+}

--- a/data/legend/metadata/hardware/detectors/germanium/crystals/V99000.json
+++ b/data/legend/metadata/hardware/detectors/germanium/crystals/V99000.json
@@ -1,0 +1,14 @@
+{
+  "name": "000",
+  "order": "99",
+  "enrichment": 0.88,
+  "impurity_measurements": {
+    "value_in_1e9e_cm3": [8, 9, 10, 10, 11],
+    "distance_from_seed_end_mm": [0, 14, 30, 50, 80]
+  },
+  "slices": {
+    "A": {
+      "detector_offset_in_mm": 80
+    }
+  }
+}


### PR DESCRIPTION
Added two crystal files for ICPC and BEGe corresponding to the respective jsons in `germanium/dioes`. The values for ICPC are taken from the Public Invcoax json; the values for BEGe are the profile of crystal B00000 with the values changed around.

Tested these files with SSD and siggen. Produce capacitance within 0.3pF with respect to the values with dummy constant impurity density.
![impurity_siggen-vs-measurements_V99000](https://github.com/legend-exp/legend-testdata/assets/39589926/3d2e2f85-fdfe-479c-884d-1c5db3affcce)
![impurity_siggen-vs-measurements_B99000](https://github.com/legend-exp/legend-testdata/assets/39589926/6ca63a37-3e00-4c53-83a4-41dfb4542d54)
