### PR TITLE
Add uncertainties to enrichment values

### DIFF
--- a/data/legend/metadata/hardware/detectors/germanium/diodes/B99000A.json
+++ b/data/legend/metadata/hardware/detectors/germanium/diodes/B99000A.json
@@ -6,7 +6,10 @@
     "order": 99,
     "crystal": "000",
     "slice": "A",
-    "enrichment": 0.75,
+    "enrichment": {
+      "val": 0.75,
+      "unc": 0.05
+    },
     "passivation": true,
     "reprocessing": false,
     "mass_in_g": 1000.0,

--- a/data/legend/metadata/hardware/detectors/germanium/diodes/C99000A.json
+++ b/data/legend/metadata/hardware/detectors/germanium/diodes/C99000A.json
@@ -6,7 +6,10 @@
     "order": 0,
     "crystal": "000",
     "slice": "A",
-    "enrichment": 0.75,
+    "enrichment": {
+      "val": 0.75,
+      "unc": 0.05
+    },
     "passivation": false,
     "reprocessing": true,
     "mass_in_g": 2000,

--- a/data/legend/metadata/hardware/detectors/germanium/diodes/P99000A.json
+++ b/data/legend/metadata/hardware/detectors/germanium/diodes/P99000A.json
@@ -6,7 +6,10 @@
     "order": 0,
     "crystal": "000",
     "slice": "A",
-    "enrichment": 0.75,
+    "enrichment": {
+      "val": 0.75,
+      "unc": 0.05
+    },
     "passivation": true,
     "reprocessing": false,
     "mass_in_g": 1000.0,

--- a/data/legend/metadata/hardware/detectors/germanium/diodes/V99000A.json
+++ b/data/legend/metadata/hardware/detectors/germanium/diodes/V99000A.json
@@ -6,7 +6,10 @@
     "order": 99,
     "crystal": "000",
     "slice": "A",
-    "enrichment": 0.75,
+    "enrichment": {
+      "val": 0.75,
+      "unc": 0.05
+    },
     "passivation": true,
     "reprocessing": false,
     "mass_in_g": 2500.0,


### PR DESCRIPTION
This is an update to the `legend-testdata`, following the format change in `legend-metadata` in which uncertainties were added to the enrichment values.