### PR TITLE
Add uncertainties to enrichment values - Part 2

### DIFF
--- a/data/ldsim/invcoax-metadata.json
+++ b/data/ldsim/invcoax-metadata.json
@@ -6,7 +6,10 @@
       "order": 0,
       "crystal": "000",
       "slice": "X",
-      "enrichment": 0.9,
+      "enrichment": {
+        "val": 0.9,
+        "unc": 0.05
+      },
       "passivation": true,
       "reprocessing": false,
       "mass_in_g": 1700,

--- a/data/legend/metadata/hardware/detectors/germanium/crystals/B99000.json
+++ b/data/legend/metadata/hardware/detectors/germanium/crystals/B99000.json
@@ -1,7 +1,6 @@
 {
   "name": "000",
   "order": "99",
-  "enrichment": 0.88,
   "impurity_measurements": {
     "value_in_1e9e_cm3": [9, 10, 12, 13, 20],
     "distance_from_seed_end_mm": [0, 27, 50, 80, 110]

--- a/data/legend/metadata/hardware/detectors/germanium/crystals/V99000.json
+++ b/data/legend/metadata/hardware/detectors/germanium/crystals/V99000.json
@@ -1,7 +1,6 @@
 {
   "name": "000",
   "order": "99",
-  "enrichment": 0.88,
   "impurity_measurements": {
     "value_in_1e9e_cm3": [8, 9, 10, 10, 11],
     "distance_from_seed_end_mm": [0, 14, 30, 50, 80]


### PR DESCRIPTION
In #16, forgot to update some `enrichment` fields in other files.
In this PR, the `enrichment` fields are updated in all detector files and removed from the crystal files.