### PR TITLE
Change dead layer thickness in V99000A.yaml

### DIFF
--- a/data/legend/metadata/hardware/detectors/germanium/diodes/V99000A.yaml
+++ b/data/legend/metadata/hardware/detectors/germanium/diodes/V99000A.yaml
@@ -54,7 +54,7 @@ characterization:
     recommended_voltage_in_V: 4000.0
     fwhm_co57fep_in_keV: 0
     fwhm_co60fep_in_keV: 0
-    dl_thickness_in_mm: 0
+    dl_thickness_in_mm: 1
   l200_site:
     daq: dummydaq
     depletion_voltage_in_V: 4000.0


### PR DESCRIPTION
All contacts should be given a thickness in SSD to prevent charge drift convergence errors. Since `LegendDataManagement.jl` takes `meta.characterization.manufacturer.dl_thickness_in_mm` as n+ contact thickness, this value needs to be given a value > 0.