### PR TITLE
add second setup to dataflow-config.yaml

### DIFF
--- a/data/legend/dataflow-config.yaml
+++ b/data/legend/dataflow-config.yaml
@@ -10,3 +10,4 @@ paths:
 
   log: "$_/generated/log"
   plt: "$_/generated/plt"
+dataset: "valid"


### PR DESCRIPTION
I implemented the possibility to use different datasets in the JuLeAna dataflow. 
To test this I want to add second setup with a different dataset to the dataflow-config.yaml