### PR TITLE
Add julia dataflow-config

### DIFF
--- a/data/legend/julia-dataflow-config.yaml
+++ b/data/legend/julia-dataflow-config.yaml
@@ -1,0 +1,15 @@
+setups:
+  l200:
+    paths:
+      metadata: "$_/metadata"
+
+      tier: "$_/generated/tier"
+      tier/raw: "/some/other/storage/raw_lh5"
+      tier_dsp: "$_/generated/tier/dsp"
+
+      par: "$_/generated/par"
+      par/dsp": "$_/generated/par/dsp"
+
+      log: "$_/generated/log"
+      plt: "$_/generated/plt"
+    dataset: "valid"


### PR DESCRIPTION
Hi,
could we add a Julia-specific dataflow-config to the test data?
We would like to keep the existing `setups: l200:` structure-based setup that you droped for pygama.